### PR TITLE
[MSYS-545] Add code to delete certificate from cert_store.

### DIFF
--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -54,6 +54,12 @@ module Win32
       return add
     end
 
+    def delete(certificate_name)
+      delete_cert = cert_delete(@certstore_handler, certificate_name)
+      close
+      return delete_cert
+    end
+
     private
     
     attr_reader :certstore_handler

--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -55,9 +55,9 @@ module Win32
     end
 
     def delete(certificate_name)
-      delete_cert = cert_delete(@certstore_handler, certificate_name)
+      delete_cert = cert_delete(certstore_handler, certificate_name)
       close
-      return delete_cert
+      delete_cert
     end
 
     private

--- a/lib/win32/certstore/mixin/crypto.rb
+++ b/lib/win32/certstore/mixin/crypto.rb
@@ -109,6 +109,8 @@ module Win32
       safe_attach_function :CertDuplicateCertificateContext, [PCCERT_CONTEXT], PCCERT_CONTEXT
       # Delete certification from certification store
       safe_attach_function :CertDeleteCertificateFromStore, [PCCERT_CONTEXT], :BOOL
+      # To retrieve specific certificates from certificate store
+      safe_attach_function :CertFindCertificateInStore, [HCERTSTORE, :DWORD, :DWORD, :DWORD, :LPVOID, PCCERT_CONTEXT], PCCERT_CONTEXT
     end
   end
 end

--- a/lib/win32/certstore/mixin/crypto.rb
+++ b/lib/win32/certstore/mixin/crypto.rb
@@ -105,6 +105,10 @@ module Win32
       safe_attach_function :CertAddEncodedCertificateToStore, [HCERTSTORE, :DWORD, :PWSTR, :DWORD, :INT_PTR, PCCERT_CONTEXT], :BOOL
 
       safe_attach_function :CertSerializeCertificateStoreElement, [PCCERT_CONTEXT, :DWORD, :pointer, :DWORD], :BOOL
+      # Duplicates a certificate context by incrementing its reference count
+      safe_attach_function :CertDuplicateCertificateContext, [PCCERT_CONTEXT], PCCERT_CONTEXT
+      # Delete certification from certification store
+      safe_attach_function :CertDeleteCertificateFromStore, [PCCERT_CONTEXT], :BOOL
     end
   end
 end

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -58,6 +58,26 @@ module Win32
         end
       end
 
+      def cert_delete(store_handler, certificate_name)
+        cert_name = FFI::MemoryPointer.new(2, 128)
+        begin
+          while (pCertContext = CertEnumCertificatesInStore(store_handler, pCertContext) and not pCertContext.null? ) do
+            if (CertGetNameStringW(pCertContext, CERT_NAME_FRIENDLY_DISPLAY_TYPE, CERT_NAME_ISSUER_FLAG, nil,cert_name, 1024) &&
+              cert_name.read_wstring.downcase == certificate_name.downcase)
+              if CertDeleteCertificateFromStore(CertDuplicateCertificateContext(pCertContext))
+                return "Deleted certificate #{certificate_name} successfully"
+              else
+                lookup_error
+              end
+            end
+          end
+          return "Cannot find certificate with name as `#{certificate_name}`. Please re-verify certificate Issuer name or Friendly name"
+        rescue Exception => e
+          @error = "delete: "
+          lookup_error
+        end
+      end
+
       private
 
       def lookup_error(failed_operation = nil)
@@ -73,6 +93,8 @@ module Win32
           raise Chef::Exceptions::Win32APIError, "ASN1 bad tag value met. -- Is the certificate in DER format?"
         when -2146881278
           raise Chef::Exceptions::Win32APIError, "ASN1 unexpected end of data."
+        when -2147024891
+          raise Chef::Exceptions::Win32APIError, "System.UnauthorizedAccessException, Access denied.."
         else
           raise Chef::Exceptions::Win32APIError, "Unable to #{failed_operation} certificate with error: #{last_error}."
         end

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -59,16 +59,12 @@ module Win32
       end
 
       def cert_delete(store_handler, certificate_name)
-        cert_name = FFI::MemoryPointer.new(2, 128)
         begin
-          while (pCertContext = CertEnumCertificatesInStore(store_handler, pCertContext) and not pCertContext.null? ) do
-            if (CertGetNameStringW(pCertContext, CERT_NAME_FRIENDLY_DISPLAY_TYPE, CERT_NAME_ISSUER_FLAG, nil,cert_name, 1024) &&
-              cert_name.read_wstring.downcase == certificate_name.downcase)
-              if CertDeleteCertificateFromStore(CertDuplicateCertificateContext(pCertContext))
-                return "Deleted certificate #{certificate_name} successfully"
-              else
-                lookup_error
-              end
+          if ( pCertContext = CertFindCertificateInStore(store_handler, X509_ASN_ENCODING, 0, CERT_NAME_FRIENDLY_DISPLAY_TYPE, certificate_name, nil) and not pCertContext.null? )
+            if CertDeleteCertificateFromStore(CertDuplicateCertificateContext(pCertContext))
+              return "Deleted certificate #{certificate_name} successfully"
+            else
+              lookup_error
             end
           end
           return "Cannot find certificate with name as `#{certificate_name}`. Please re-verify certificate Issuer name or Friendly name"

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -90,7 +90,7 @@ describe Win32::Certstore, :windows_only do
       let (:store_name) { "my" }
       let (:certificate_name) { "tmp_cert.mydomain.com" }
       it "return message of `Cannot find certificate`" do
-        allow(certbase).to receive(:CertFindCertificateInStore).and_return(false)
+        allow_any_instance_of(certbase).to receive(:CertFindCertificateInStore).and_return(false)
         store = certstore.open(store_name)
         delete_cert = store.delete(certificate_name)
         expect(delete_cert).to eq("Cannot find certificate with name as `tmp_cert.mydomain.com`. Please re-verify certificate Issuer name or Friendly name")
@@ -101,7 +101,7 @@ describe Win32::Certstore, :windows_only do
       let (:store_name) { "my" }
       let (:certificate_name) { "" }
       it "return message of `Cannot find certificate`" do
-        allow(certbase).to receive(:CertFindCertificateInStore).and_return(false)
+        allow_any_instance_of(certbase).to receive(:CertFindCertificateInStore).and_return(false)
         store = certstore.open(store_name)
         delete_cert = store.delete(certificate_name)
         expect(delete_cert).to eq("Cannot find certificate with name as ``. Please re-verify certificate Issuer name or Friendly name")

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -76,6 +76,7 @@ describe Win32::Certstore, :windows_only do
       let (:store_name) { "ca" }
       let (:certificate_name) { 'GeoTrust Global CA' }
       before(:each) do
+        allow(certbase).to receive_message_chain(:CertFindCertificateInStore, :last).and_return(true)
         allow_any_instance_of(certbase).to receive(:CertDeleteCertificateFromStore).and_return(true)
       end
       it "return message of successful deletion" do
@@ -89,7 +90,7 @@ describe Win32::Certstore, :windows_only do
       let (:store_name) { "my" }
       let (:certificate_name) { "tmp_cert.mydomain.com" }
       it "return message of `Cannot find certificate`" do
-        allow(certbase).to receive(:CertDeleteCertificateFromStore).and_return(false)
+        allow(certbase).to receive(:CertFindCertificateInStore).and_return(false)
         store = certstore.open(store_name)
         delete_cert = store.delete(certificate_name)
         expect(delete_cert).to eq("Cannot find certificate with name as `tmp_cert.mydomain.com`. Please re-verify certificate Issuer name or Friendly name")
@@ -100,7 +101,7 @@ describe Win32::Certstore, :windows_only do
       let (:store_name) { "my" }
       let (:certificate_name) { "" }
       it "return message of `Cannot find certificate`" do
-        allow(certbase).to receive(:CertDeleteCertificateFromStore).and_return(false)
+        allow(certbase).to receive(:CertFindCertificateInStore).and_return(false)
         store = certstore.open(store_name)
         delete_cert = store.delete(certificate_name)
         expect(delete_cert).to eq("Cannot find certificate with name as ``. Please re-verify certificate Issuer name or Friendly name")
@@ -158,6 +159,7 @@ describe Win32::Certstore, :windows_only do
       end
 
        it "return 'System.UnauthorizedAccessException, Access denied..'" do
+        allow(certbase).to receive(:CertFindCertificateInStore).and_return(true)
         allow(certbase).to receive(:CertDeleteCertificateFromStore).and_return(false)
         allow(FFI::LastError).to receive(:error).and_return(-2147024891)
         store = certstore.open(store_name)

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -72,10 +72,46 @@ describe Win32::Certstore, :windows_only do
       end
     end
 
+    context "When deleting valid certificate" do
+      let (:store_name) { "ca" }
+      let (:certificate_name) { 'GeoTrust Global CA' }
+      before(:each) do
+        allow_any_instance_of(certbase).to receive(:CertDeleteCertificateFromStore).and_return(true)
+      end
+      it "return message of successful deletion" do
+        store = certstore.open(store_name)
+        delete_cert = store.delete(certificate_name)
+        expect(delete_cert).to eq("Deleted certificate GeoTrust Global CA successfully")
+      end
+    end
+
+    context "When deleting invalid certificate" do
+      let (:store_name) { "my" }
+      let (:certificate_name) { "tmp_cert.mydomain.com" }
+      it "return message of `Cannot find certificate`" do
+        allow(certbase).to receive(:CertDeleteCertificateFromStore).and_return(false)
+        store = certstore.open(store_name)
+        delete_cert = store.delete(certificate_name)
+        expect(delete_cert).to eq("Cannot find certificate with name as `tmp_cert.mydomain.com`. Please re-verify certificate Issuer name or Friendly name")
+      end
+    end
+
+    context "When passing empty certificate_name to delete it" do
+      let (:store_name) { "my" }
+      let (:certificate_name) { "" }
+      it "return message of `Cannot find certificate`" do
+        allow(certbase).to receive(:CertDeleteCertificateFromStore).and_return(false)
+        store = certstore.open(store_name)
+        delete_cert = store.delete(certificate_name)
+        expect(delete_cert).to eq("Cannot find certificate with name as ``. Please re-verify certificate Issuer name or Friendly name")
+      end
+    end
+
     context "When adding certificate failed with FFI::LastError" do
       let (:store_name) { "root" }
       let (:cert_file_path) { '.\win32\unit\assets\test.cer' }
-      
+      let (:certificate_name) { 'GlobalSign' }
+
       it "returns 'The operation was canceled by the user'" do
         allow(certstore_obj).to receive(:CertAddEncodedCertificateToStore).and_return(false)
         allow(FFI::LastError).to receive(:error).and_return(1223)
@@ -119,6 +155,13 @@ describe Win32::Certstore, :windows_only do
         allow(FFI::LastError).to receive(:error).and_return(-2146881278)
         store = certstore.open(store_name)
         expect { store.add(cert_file_path) }.to raise_error("ASN1 unexpected end of data.")
+      end
+
+       it "return 'System.UnauthorizedAccessException, Access denied..'" do
+        allow(certbase).to receive(:CertDeleteCertificateFromStore).and_return(false)
+        allow(FFI::LastError).to receive(:error).and_return(-2147024891)
+        store = certstore.open(store_name)
+        expect { store.delete(certificate_name) }.to raise_error(Chef::Exceptions::Win32APIError)
       end
     end
   end


### PR DESCRIPTION
Added code to delete single certificate from cert_store.
We can delete the certificate & check as: 
```
store = Win32::Certstore.open("root")
cert = store.delete('Frank4DD Web CA')
puts "output : #{cert}"
```