### PR TITLE
[MSYS-544]: Retrieve properties of a single certificate

### DIFF
--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -61,6 +61,12 @@ module Win32
       delete_cert
     end
 
+    def retrieve(certificate_name)
+      retrieve_cert = cert_retrieve(certstore_handler, certificate_name)
+      close
+      retrieve_cert
+    end
+
     private
     
     attr_reader :certstore_handler

--- a/lib/win32/certstore/mixin/crypto.rb
+++ b/lib/win32/certstore/mixin/crypto.rb
@@ -66,6 +66,11 @@ module Win32
       CERT_NAME_URL_TYPE                                  = 7
       CERT_NAME_UPN_TYPE                                  = 8
 
+      # Retrieve Certificates flag
+      # https://sourceforge.net/p/mingw/mingw-org-wsl/ci/987711554626e4710ad73ce7e44aece511672020/tree/w32api/include/wincrypt.h?format=raw.
+      CERT_FIND_SUBJECT_STR                               = 0x00080007
+      CERT_FIND_ISSUER_STR                                = 0x00080004
+
       # List Certificates Flag
       CERT_NAME_ISSUER_FLAG                               = 0x1
       CERT_NAME_DISABLE_IE4_UTF8_FLAG                     = 0x00010000

--- a/lib/win32/certstore/mixin/crypto.rb
+++ b/lib/win32/certstore/mixin/crypto.rb
@@ -67,7 +67,6 @@ module Win32
       CERT_NAME_UPN_TYPE                                  = 8
 
       # Retrieve Certificates flag
-      # https://sourceforge.net/p/mingw/mingw-org-wsl/ci/987711554626e4710ad73ce7e44aece511672020/tree/w32api/include/wincrypt.h?format=raw.
       CERT_FIND_SUBJECT_STR                               = 0x00080007
       CERT_FIND_ISSUER_STR                                = 0x00080004
 

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -82,6 +82,22 @@ module Win32
         end
       end
 
+    def cert_retrieve(store_handler, certificate_name)
+        property_value = FFI::MemoryPointer.new(2, 128)
+        retrieve = { CERT_NAME_EMAIL_TYPE: nil, CERT_NAME_RDN_TYPE: nil, CERT_NAME_ATTR_TYPE: nil, CERT_NAME_SIMPLE_DISPLAY_TYPE: nil, CERT_NAME_FRIENDLY_DISPLAY_TYPE: nil, CERT_NAME_DNS_TYPE: nil, CERT_NAME_URL_TYPE: nil, CERT_NAME_UPN_TYPE: nil }
+        begin
+          if ( pCertContext = CertFindCertificateInStore(store_handler, X509_ASN_ENCODING, 0, CERT_NAME_FRIENDLY_DISPLAY_TYPE, certificate_name, nil) and not pCertContext.null? )
+            retrieve.each do |property_type, value|
+              CertGetNameStringW(pCertContext, eval(property_type.to_s), CERT_NAME_ISSUER_FLAG, nil, property_value, 1024)
+              retrieve[property_type] = property_value.read_wstring
+            end
+          end
+        rescue Exception => e
+          @error = "retrieve: "
+          lookup_error
+        end
+    end
+
       private
 
       def lookup_error(failed_operation = nil)

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -82,21 +82,25 @@ module Win32
         end
       end
 
-    def cert_retrieve(store_handler, certificate_name)
+      def cert_retrieve(store_handler, certificate_name)
         property_value = FFI::MemoryPointer.new(2, 128)
-        retrieve = { CERT_NAME_EMAIL_TYPE: nil, CERT_NAME_RDN_TYPE: nil, CERT_NAME_ATTR_TYPE: nil, CERT_NAME_SIMPLE_DISPLAY_TYPE: nil, CERT_NAME_FRIENDLY_DISPLAY_TYPE: nil, CERT_NAME_DNS_TYPE: nil, CERT_NAME_URL_TYPE: nil, CERT_NAME_UPN_TYPE: nil }
+        retrieve = { CERT_NAME_EMAIL_TYPE: nil, CERT_NAME_RDN_TYPE: nil, CERT_NAME_ATTR_TYPE: nil,
+          CERT_NAME_SIMPLE_DISPLAY_TYPE: nil, CERT_NAME_FRIENDLY_DISPLAY_TYPE: nil, CERT_NAME_DNS_TYPE: nil,
+          CERT_NAME_URL_TYPE: nil, CERT_NAME_UPN_TYPE: nil }
         begin
-          if ( pCertContext = CertFindCertificateInStore(store_handler, X509_ASN_ENCODING, 0, CERT_NAME_FRIENDLY_DISPLAY_TYPE, certificate_name, nil) and not pCertContext.null? )
+          if ( ! certificate_name.empty? and pCertContext = CertFindCertificateInStore(store_handler, X509_ASN_ENCODING, 0, CERT_FIND_ISSUER_STR, certificate_name.to_wstring, nil) and not pCertContext.null? )
             retrieve.each do |property_type, value|
               CertGetNameStringW(pCertContext, eval(property_type.to_s), CERT_NAME_ISSUER_FLAG, nil, property_value, 1024)
               retrieve[property_type] = property_value.read_wstring
             end
+            return retrieve
           end
+          return "Cannot find certificate with name as `#{certificate_name}`. Please re-verify certificate Issuer name"
         rescue Exception => e
           @error = "retrieve: "
           lookup_error
         end
-    end
+      end
 
       private
 

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -24,7 +24,7 @@ describe Win32::Certstore, :windows_only do
   let (:certstore_obj) { Win32::Certstore.new(store_name) }
   let (:certbase) { Win32::Certstore::StoreBase }
   
-  describe "#list" do
+  describe "#cert_list" do
     context "When passing empty certificate store name" do
       let (:store_name) { "" }
       it "raises ArgumentError" do
@@ -39,14 +39,14 @@ describe Win32::Certstore, :windows_only do
       end
     end
 
-    context "When passing empty certificate store name" do
+    context "When passing nil certificate store name" do
       let (:store_name) { nil }
       it "raises ArgumentError" do
         expect { certstore.open(store_name) }.to raise_error("Invalid Certificate Store.")
       end
     end
 
-    context "When passing valid certificate store name" do
+    context "When passing valid certificate" do
       let (:store_name) { "root" }
       let (:root_certificate_name) { "Microsoft Root Certificate Authority"}
       before(:each) do
@@ -59,8 +59,10 @@ describe Win32::Certstore, :windows_only do
         expect(certificate_list.first).to eql root_certificate_name
       end
     end
+  end
 
-    context "When adding invalid certificate" do
+  describe "#cert_add" do
+    context "When passing invalid certificate" do
       let (:store_name) { "root" }
       let (:cert_file_path) { '.\win32\unit\assets\test.cer' }
       it "returns no certificate list" do
@@ -72,7 +74,20 @@ describe Win32::Certstore, :windows_only do
       end
     end
 
-    context "When deleting valid certificate" do
+    context "When invalid certificate path is given" do
+      let (:store_name) { "my" }
+      let (:cert_file_path) { '.\win32\unit\test.cer' }
+
+      it "raises Mixlib::ShellOut::ShellCommandFailed" do
+        allow(certbase).to receive(:CertAddEncodedCertificateToStore).and_return(false)
+        store = certstore.open(store_name)
+        expect { store.add(cert_file_path) }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
+      end
+    end
+  end
+
+  describe "#cert_delete" do
+    context "When passing valid certificate" do
       let (:store_name) { "ca" }
       let (:certificate_name) { 'GeoTrust Global CA' }
       before(:each) do
@@ -86,10 +101,10 @@ describe Win32::Certstore, :windows_only do
       end
     end
 
-    context "When deleting invalid certificate" do
+    context "When passing invalid certificate" do
       let (:store_name) { "my" }
       let (:certificate_name) { "tmp_cert.mydomain.com" }
-      it "return message of `Cannot find certificate`" do
+      it "returns a message: `Cannot find Certificate`" do
         allow_any_instance_of(certbase).to receive(:CertFindCertificateInStore).and_return(false)
         store = certstore.open(store_name)
         delete_cert = store.delete(certificate_name)
@@ -97,18 +112,20 @@ describe Win32::Certstore, :windows_only do
       end
     end
 
-    context "When passing empty certificate_name to delete it" do
+    context "When passing empty certificate_name" do
       let (:store_name) { "my" }
       let (:certificate_name) { "" }
-      it "return message of `Cannot find certificate`" do
+      it "returns a message: `Cannot find Certificate`" do
         allow_any_instance_of(certbase).to receive(:CertFindCertificateInStore).and_return(false)
         store = certstore.open(store_name)
         delete_cert = store.delete(certificate_name)
         expect(delete_cert).to eq("Cannot find certificate with name as ``. Please re-verify certificate Issuer name or Friendly name")
       end
     end
+  end
 
-    context "When retrieve valid certificate" do
+  describe "#cert_retrieve" do
+    context "When passing valid certificate" do
       let (:store_name) { "my" }
       let (:certificate_name) { 'GeoTrust Global CA' }
       let (:retrieve) { { CERT_NAME_ATTR_TYPE: "GeoTrust Global CA", CERT_NAME_DNS_TYPE: "GeoTrust Global CA",
@@ -121,17 +138,17 @@ describe Win32::Certstore, :windows_only do
         allow_any_instance_of(certbase).to receive_message_chain(:CertFindCertificateInStore, :last).and_return(true)
       end
 
-      it "return message of successful deletion" do
+      it "returns certificate properties" do
         store = certstore.open(store_name)
         retrive_cert = store.retrieve(certificate_name)
         expect(retrive_cert).to eq(retrieve)
       end
     end
 
-    context "When retrieve invalid certificate" do
+    context "When passing invalid certificate" do
       let (:store_name) { "my" }
       let (:certificate_name) { "tmp_cert.mydomain.com" }
-      it "return message of `Cannot find certificate`" do
+      it "returns a message: `Cannot find Certificate`" do
         allow_any_instance_of(certbase).to receive(:CertFindCertificateInStore).and_return(false)
         store = certstore.open(store_name)
         delete_cert = store.retrieve(certificate_name)
@@ -139,18 +156,20 @@ describe Win32::Certstore, :windows_only do
       end
     end
 
-    context "When passing empty certificate_name to retrieve it" do
+    context "When passing empty certificate_name" do
       let (:store_name) { "my" }
       let (:certificate_name) { "" }
-      it "return message of `Cannot find certificate`" do
+      it "returns a message: `Cannot find Certificate`" do
         allow_any_instance_of(certbase).to receive(:CertFindCertificateInStore).and_return(false)
         store = certstore.open(store_name)
         delete_cert = store.retrieve(certificate_name)
         expect(delete_cert).to eq("Cannot find certificate with name as ``. Please re-verify certificate Issuer name")
       end
     end
+  end
 
-    context "When adding certificate failed with FFI::LastError" do
+  describe "#Failed with FFI::LastError" do
+    context "While adding or deleting or retrieving certificate" do
       let (:store_name) { "root" }
       let (:cert_file_path) { '.\win32\unit\assets\test.cer' }
       let (:certificate_name) { 'GlobalSign' }
@@ -206,17 +225,6 @@ describe Win32::Certstore, :windows_only do
         allow(FFI::LastError).to receive(:error).and_return(-2147024891)
         store = certstore.open(store_name)
         expect { store.delete(certificate_name) }.to raise_error(SystemCallError)
-      end
-    end
-
-    context "When invalid certificate path is given" do
-      let (:store_name) { "my" }
-      let (:cert_file_path) { '.\win32\unit\test.cer' }
-
-      it "raises Mixlib::ShellOut::ShellCommandFailed" do
-        allow(certbase).to receive(:CertAddEncodedCertificateToStore).and_return(false)
-        store = certstore.open(store_name)
-        expect { store.add(cert_file_path) }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
       end
     end
   end


### PR DESCRIPTION
We can retrieve properties of specific certificate with ruby code as: 
```
store = Win32::Certstore.open("MY")
a = store.retrieve('Frank4DD Web CA')
p "o/p : #{a}"	
```
and get output in format as : 
```
"o/p : {:CERT_NAME_EMAIL_TYPE=>\"support@frank4dd.com\", :CERT_NAME_RDN_TYPE=>\"JP, Tokyo, Chuo-ku, Frank4DD, WebCert Support, Frank4DD Web CA, support@frank4dd.com\", :CERT_NAME_ATTR_TYPE=>\"
support@frank4dd.com\", :CERT_NAME_SIMPLE_DISPLAY_TYPE=>\"Frank4DD Web CA\", :CERT_NAME_FRIENDLY_DISPLAY_TYPE=>\"Frank4DD Web CA\", :CERT_NAME_DNS_TYPE=>\"Frank4DD Web CA\", :CERT_NAME_URL_TYP
E=>\"\", :CERT_NAME_UPN_TYPE=>\"\"}"
```