### PR TITLE
[MSYS-767] Win32-certstore - search certificate.

### DIFF
--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -66,8 +66,8 @@ module Win32
     end
 
     # Search certificate from open certificate store and return certificates objects
-    def search(certificate_name)
-      cert_search(certstore_handler, certificate_name)
+    def search(search_token)
+      cert_search(certstore_handler, search_token)
     end
 
     # Validate certificate from open certificate store and return boolean

--- a/lib/win32/certstore/mixin/assertions.rb
+++ b/lib/win32/certstore/mixin/assertions.rb
@@ -46,10 +46,11 @@ module Win32
           if cert_thumbprint.nil? || cert_thumbprint.strip.empty?
             raise ArgumentError, "Invalid certificate thumbprint."
           end
+        end
 
         # Validate certificate name not nil/empty
-        def validate_certificate_name(cert_name)
-          raise ArgumentError, "Invalid Certificate name" if cert_name.strip.empty?
+        def validate!(token)
+          raise ArgumentError, "Invalid search token" if !token || token.strip.empty?
         end
 
         # Common System call errors

--- a/lib/win32/certstore/mixin/assertions.rb
+++ b/lib/win32/certstore/mixin/assertions.rb
@@ -46,6 +46,10 @@ module Win32
           if cert_thumbprint.nil? || cert_thumbprint.strip.empty?
             raise ArgumentError, "Invalid certificate thumbprint."
           end
+
+        # Validate certificate name not nil/empty
+        def validate_certificate_name(cert_name)
+          raise ArgumentError, "Invalid Certificate name" if cert_name.strip.empty?
         end
 
         # Common System call errors

--- a/lib/win32/certstore/mixin/crypto.rb
+++ b/lib/win32/certstore/mixin/crypto.rb
@@ -195,6 +195,8 @@ module Win32
         safe_attach_function :CertDeleteCertificateFromStore, [PCCERT_CONTEXT], BOOL
         # To retrieve specific certificates from certificate store
         safe_attach_function :CertFindCertificateInStore, [HCERTSTORE, DWORD, DWORD, DWORD, LPVOID, PCCERT_CONTEXT], PCCERT_CONTEXT
+        
+        safe_attach_function :PFXExportCertStoreEx, [HCERTSTORE, CRYPT_INTEGER_BLOB, LPCTSTR, LPVOID, DWORD], BOOL
       end
     end
   end


### PR DESCRIPTION
**Note:** First merge PR: #16 after that need to rebase this branch.

**Description:**
This method search certificate by CN, Friendly_name, Simple_display_name, DNS, URL, UPN and other attributes and return match certificate hash.

**Usages:**
```
Win32::Certstore.open("ROOT") do |store|
  search_certificate_data = store.search("GlobalSign Root CA")
  store.close
end
```
**Note:**  Here search_certificate_data is Hash that contain Friendly_name and RDN Like:.
```
certificate_list{ certificate1: {friendly_name: "Friendly Name", rdn: "RDN"}, certificate2: {friendly_name: "Friendly Name", rdn: "RDN"}, ..}
```