### PR TITLE
[MSYS-769] Win32-certstore - get certificate

### DIFF
--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -17,6 +17,7 @@
 
 require_relative "certstore/mixin/crypto"
 require_relative "certstore/mixin/assertions"
+require_relative "certstore/mixin/helper"
 require_relative "certstore/mixin/string"
 require_relative "certstore/store_base"
 require_relative "certstore/version"

--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -52,7 +52,7 @@ module Win32
 
     # Get certificate from certificate store and return certificate object
     def get(certificate_thumbprint)
-      cert_get(certstore_handler, certificate_thumbprint)
+      cert_get(certificate_thumbprint)
     end
 
     # Listing all certificate of open certificate store and return in certificates list

--- a/lib/win32/certstore/mixin/assertions.rb
+++ b/lib/win32/certstore/mixin/assertions.rb
@@ -41,6 +41,13 @@ module Win32
           end
         end
 
+        # Validate thumbprint
+        def validate_thumbprint(cert_thumbprint)
+          if cert_thumbprint.nil? || cert_thumbprint.strip.empty?
+            raise ArgumentError, "Invalid certificate thumbprint."
+          end
+        end
+
         # Common System call errors
         def lookup_error(failed_operation = nil)
           error_no = FFI::LastError.error

--- a/lib/win32/certstore/mixin/helper.rb
+++ b/lib/win32/certstore/mixin/helper.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,18 +22,19 @@ module Win32
 
         # PSCommand to search certificate from thumbprint and convert in pem
         def cert_ps_cmd(thumbprint)
-          "$CertThumbprint = '#{thumbprint}'
-          $content = $null
-          $cert = Get-ChildItem Cert:\ -Recurse | Where-Object { $_.Thumbprint -eq $CertThumbprint } | Select-Object -First 1
-          if($cert -ne $null)
-          {
-          $content = @(
-            '-----BEGIN CERTIFICATE-----'
-            [System.Convert]::ToBase64String($cert.RawData, 'InsertLineBreaks')
-            '-----END CERTIFICATE-----'
-          )
-          }
-          $content"
+          <<-EOH
+            $content = $null
+            $cert = Get-ChildItem Cert:\ -Recurse | Where { $_.Thumbprint -eq '#{thumbprint}' }
+            if($cert -ne $null)
+            {
+            $content = @(
+              '-----BEGIN CERTIFICATE-----'
+              [System.Convert]::ToBase64String($cert.RawData, 'InsertLineBreaks')
+              '-----END CERTIFICATE-----'
+            )
+            }
+            $content
+          EOH
         end
       end
     end

--- a/lib/win32/certstore/mixin/helper.rb
+++ b/lib/win32/certstore/mixin/helper.rb
@@ -1,0 +1,42 @@
+#
+# Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Win32
+  class Certstore
+    module Mixin
+      module Helper
+
+        # PSCommand to search certificate from thumbprint and convert in pem
+        def cert_ps_cmd(thumbprint)
+          "$CertThumbprint = '#{thumbprint}'
+          $content = $null
+          $cert = Get-ChildItem Cert:\ -Recurse | Where-Object { $_.Thumbprint -eq $CertThumbprint } | Select-Object -First 1
+          if($cert -ne $null)
+          {
+          $content = @(
+            '-----BEGIN CERTIFICATE-----'
+            [System.Convert]::ToBase64String($cert.RawData, 'InsertLineBreaks')
+            '-----END CERTIFICATE-----'
+          )
+          }
+          $content"
+        end
+      end
+    end
+  end
+end
+

--- a/lib/win32/certstore/mixin/shell_out.rb
+++ b/lib/win32/certstore/mixin/shell_out.rb
@@ -30,6 +30,74 @@ module Win32
           end
           cmd
         end
+        # Run a command under powershell with the same API as shell_out.  The
+        # options hash is extended to take an "architecture" flag which
+        # can be set to :i386 or :x86_64 to force the windows architecture.
+        #
+        # @param script [String] script to run
+        # @param options [Hash] options hash
+        # @return [Mixlib::Shellout] mixlib-shellout object
+        def powershell_out(*command_args)
+          script = command_args.first
+          options = command_args.last.is_a?(Hash) ? command_args.last : nil
+
+          run_command_with_os_architecture(script, options)
+        end
+
+        # Run a command under powershell with the same API as shell_out!
+        # (raises exceptions on errors)
+        #
+        # @param script [String] script to run
+        # @param options [Hash] options hash
+        # @return [Mixlib::Shellout] mixlib-shellout object
+        def powershell_out!(*command_args)
+          cmd = powershell_out(*command_args)
+          cmd.error!
+          cmd
+        end
+
+        private
+
+        # Helper function to run shell_out and wrap it with the correct
+        # flags to possibly disable WOW64 redirection (which we often need
+        # because chef-client runs as a 32-bit app on 64-bit windows).
+        #
+        # @param script [String] script to run
+        # @param options [Hash] options hash
+        # @return [Mixlib::Shellout] mixlib-shellout object
+        def run_command_with_os_architecture(script, options)
+          options ||= {}
+          options = options.dup
+          arch = options.delete(:architecture)
+
+          shell_out_command(
+            build_powershell_command(script),
+            options
+          )
+        end
+
+        # Helper to build a powershell command around the script to run.
+        #
+        # @param script [String] script to run
+        # @return [String] powershell command to execute
+        def build_powershell_command(script)
+          flags = [
+            # Hides the copyright banner at startup.
+            "-NoLogo",
+            # Does not present an interactive prompt to the user.
+            "-NonInteractive",
+            # Does not load the Windows PowerShell profile.
+            "-NoProfile",
+            # always set the ExecutionPolicy flag
+            # see http://technet.microsoft.com/en-us/library/ee176961.aspx
+            "-ExecutionPolicy Unrestricted",
+            # Powershell will hang if STDIN is redirected
+            # http://connect.microsoft.com/PowerShell/feedback/details/572313/powershell-exe-can-hang-if-stdin-is-redirected
+            "-InputFormat None",
+          ]
+
+          "powershell.exe #{flags.join(' ')} -Command \"#{script.gsub('"', '\"')}\""
+        end
       end
     end
   end

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -21,7 +21,6 @@ require_relative "mixin/shell_out"
 require_relative "mixin/unicode"
 require "openssl"
 require "json"
-require "tempfile"
 
 module Win32
   class Certstore
@@ -31,6 +30,7 @@ module Win32
       include Win32::Certstore::Mixin::String
       include Win32::Certstore::Mixin::ShellOut
       include Win32::Certstore::Mixin::Unicode
+      include Win32::Certstore::Mixin::Helper
 
       # Adding new certification in open certificate and return boolean
       # store_handler => Open certificate store handler
@@ -53,22 +53,12 @@ module Win32
       # store_handler => Open certificate store handler
       # certificate_thumbprint => thumbprint is a hash. which could be sha1 or md5.
       def cert_get(store_handler, certificate_thumbprint)
-        property_value = memory_ptr
-        retrieve = { CERT_NAME_EMAIL_TYPE: nil, CERT_NAME_RDN_TYPE: nil, CERT_NAME_ATTR_TYPE: nil,
-                     CERT_NAME_SIMPLE_DISPLAY_TYPE: nil, CERT_NAME_FRIENDLY_DISPLAY_TYPE: nil, CERT_NAME_DNS_TYPE: nil,
-                     CERT_NAME_URL_TYPE: nil, CERT_NAME_UPN_TYPE: nil }
-        begin
-          if !certificate_name.empty? && (pcert_context = CertFindCertificateInStore(store_handler, X509_ASN_ENCODING, 0, CERT_FIND_ISSUER_STR, certificate_name.to_wstring, nil)) && (not pcert_context.null?)
-            retrieve.each do |property_type, value|
-              CertGetNameStringW(pcert_context, property_type, CERT_NAME_ISSUER_FLAG, nil, property_value, 1024)
-              retrieve[property_type] = property_value.read_wstring
-            end
-            return retrieve
-          end
-          return "Cannot find certificate with name as `#{certificate_name}`. Please re-verify certificate Issuer name"
-        rescue Exception => e
-          @error = "retrieve: "
-          lookup_error
+        validate_thumbprint(certificate_thumbprint)
+        thumbprint = update_thumbprint(certificate_thumbprint)
+        cert_pem = get_cert_pem(thumbprint)
+        unless cert_pem.empty?
+          cert_pem = format_pem(cert_pem)
+          build_openssl_obj(cert_pem)
         end
       end
 
@@ -109,10 +99,6 @@ module Win32
         end
       end
 
-      def cert_search(store_handler, certificate_name)
-        
-      end
-
       private
 
       # Build arguments for CertAddEncodedCertificateToStore
@@ -125,11 +111,30 @@ module Win32
         [pcert_context, CERT_NAME_FRIENDLY_DISPLAY_TYPE, CERT_NAME_ISSUER_FLAG, nil, cert_name, 1024]
       end
 
+      # Remove extra space and : from thumbprint
+      def update_thumbprint(certificate_thumbprint)
+        certificate_thumbprint.gsub(/[^A-Za-z0-9]/, '')
+      end
+
       # Convert OpenSSL::X509::Certificate object in .der formate
       def der_cert(cert_obj)
         FFI::MemoryPointer.from_string(cert_obj.to_der)
       end
 
+      # Get certificate pem
+      def get_cert_pem(thumbprint)
+        IO::popen(["powershell.exe", cert_ps_cmd(thumbprint)]) {|io| io.readlines}
+      end
+
+      # Format pem
+      def format_pem(cert_pem)
+        cert_pem.join
+      end
+
+      # Build pem to OpenSSL::X509::Certificate object
+      def build_openssl_obj(cert_pem)
+        OpenSSL::X509::Certificate.new cert_pem
+      end
       # Create empty memory pointer
       def memory_ptr
         FFI::MemoryPointer.new(2, 128)

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -52,12 +52,12 @@ module Win32
       # Get certificate from open certificate store and return certificate object
       # store_handler => Open certificate store handler
       # certificate_thumbprint => thumbprint is a hash. which could be sha1 or md5.
-      def cert_get(store_handler, certificate_thumbprint)
+      def cert_get(certificate_thumbprint)
         validate_thumbprint(certificate_thumbprint)
         thumbprint = update_thumbprint(certificate_thumbprint)
         cert_pem = get_cert_pem(thumbprint)
+        cert_pem = format_pem(cert_pem)
         unless cert_pem.empty?
-          cert_pem = format_pem(cert_pem)
           build_openssl_obj(cert_pem)
         end
       end
@@ -123,17 +123,18 @@ module Win32
 
       # Get certificate pem
       def get_cert_pem(thumbprint)
-        IO::popen(["powershell.exe", cert_ps_cmd(thumbprint)]) {|io| io.readlines}
+        get_data =  powershell_out!(cert_ps_cmd(thumbprint))
+        get_data.stdout
       end
 
       # Format pem
       def format_pem(cert_pem)
-        cert_pem.join
+        cert_pem.delete("\r")
       end
 
       # Build pem to OpenSSL::X509::Certificate object
       def build_openssl_obj(cert_pem)
-        OpenSSL::X509::Certificate.new cert_pem
+        OpenSSL::X509::Certificate.new(cert_pem)
       end
       # Create empty memory pointer
       def memory_ptr


### PR DESCRIPTION
**Note:** First merge PR: #16 after that need to rebase this branch.

**Description:**
This method get certificate using thumbprint and return OpenSSL::X509 certificate object.

**Usages:**
```
thumbprint = "‎75 e0 ab b6 13 85 12 27 1c 04 f8 5f dd de 38 e4 b7 24 2e fe"
Win32::Certstore.open("ROOT") do |store|
  cert_obj = store.get("‎75 e0 ab b6 13 85 12 27 1c 04 f8 5f dd de 38 e4 b7 24 2e fe")
  store.close
end
```
**Note:**  Here cert_obj is OpenSSL::X509 certificate object as.
```
#<OpenSSL::X509::Certificate
 subject=#<OpenSSL::X509::Name CN=GlobalSign Root CA,OU=Root CA,O=GlobalSign nv-sa,C=BE>,
 issuer=#<OpenSSL::X509::Name CN=GlobalSign Root CA,OU=Root CA,O=GlobalSign nv-sa,C=BE>,
 serial=#<OpenSSL::BN 4835703278459707669005204>,
 not_before=1998-09-01 12:00:00 UTC,
 not_after=2028-01-28 12:00:00 UTC>
```