### PR TITLE
Fixed FFI destroy object messages during chef run

### DIFF
--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -118,7 +118,7 @@ module Win32
     end
 
     def self.finalize(certstore_handler)
-      proc { puts "DESTROY OBJECT #{certstore_handler}" }
+      proc { "#{certstore_handler}" }
     end
 
     # To close all open certificate store at the end


### PR DESCRIPTION
Fixes https://github.com/chef/win32-certstore/issues/30

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>