### PR TITLE
[MSYS-836] fixes for ruby2.0 and FFI destroy object messages 

### DIFF
--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -118,7 +118,7 @@ module Win32
     end
 
     def self.finalize(certstore_handler)
-      proc { puts "DESTROY OBJECT #{certstore_handler}" }
+      proc { "#{certstore_handler}" }
     end
 
     # To close all open certificate store at the end

--- a/lib/win32/certstore/mixin/assertions.rb
+++ b/lib/win32/certstore/mixin/assertions.rb
@@ -22,7 +22,7 @@ module Win32
       module Assertions
         # Validate certificate store name
         def validate_store(store_name)
-          unless valid_store_name.include?(store_name&.upcase)
+          unless valid_store_name.include?(store_name.to_s.upcase)
             raise ArgumentError, "Invalid Certificate Store."
           end
         end
@@ -82,7 +82,7 @@ module Win32
         # ROOT -> Root certificates.
         # SPC -> Software Publisher Certificate.
         def valid_store_name
-          %w{MY CA ROOT SPC}
+          %w{MY CA ROOT AUTHROOT DISALLOWED SPC TRUST TRUSTEDPEOPLE TRUSTEDPUBLISHER CLIENTAUTHISSUER TRUSTEDDEVICES SMARTCARDROOT WEBHOSTING REMOTE\ DESKTOP}
         end
       end
     end


### PR DESCRIPTION
**Description:**
- Added support Ruby 2.0 also add more valid store same as windows cookbooks. 
- Fixed FFI destroy object messages

**Issues:**
- Fixes: https://github.com/chef/win32-certstore/issues/27
- Fixes: https://github.com/chef/win32-certstore/issues/30

Signed-off-by: piyushawasthi piyush.awasthi@msystechnologies.com