### PR TITLE
MSYS-856 : Removed store validation

### DIFF
--- a/lib/win32/certstore/mixin/assertions.rb
+++ b/lib/win32/certstore/mixin/assertions.rb
@@ -22,8 +22,8 @@ module Win32
       module Assertions
         # Validate certificate store name
         def validate_store(store_name)
-          unless valid_store_name.include?(store_name.to_s.upcase)
-            raise ArgumentError, "Invalid Certificate Store."
+          if store_name.to_s.strip.empty?
+            raise ArgumentError, "Empty Certificate Store."
           end
         end
 

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -29,21 +29,21 @@ describe Win32::Certstore, :windows_only do
     context "When passing empty certificate store name" do
       let(:store_name) { "" }
       it "raises ArgumentError" do
-        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Invalid Certificate Store.")
+        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Empty Certificate Store.")
       end
     end
 
     context "When passing invalid certificate store name" do
       let(:store_name) { "Chef" }
       it "raises ArgumentError" do
-        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Invalid Certificate Store.")
+        expect { certstore.open(store_name) }.not_to raise_error(ArgumentError, "Empty Certificate Store.")
       end
     end
 
     context "When passing nil certificate store name" do
       let(:store_name) { nil }
       it "raises ArgumentError" do
-        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Invalid Certificate Store.")
+        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Empty Certificate Store.")
       end
     end
 
@@ -102,7 +102,7 @@ describe Win32::Certstore, :windows_only do
     context "When passing empty certificate store name" do
       let(:store_name) { "" }
       it "raises ArgumentError" do
-        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Invalid Certificate Store.")
+        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Empty Certificate Store.")
       end
     end
 
@@ -190,7 +190,7 @@ describe Win32::Certstore, :windows_only do
     context "When passing empty certificate store name" do
       let(:store_name) { "" }
       it "raises ArgumentError" do
-        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Invalid Certificate Store.")
+        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Empty Certificate Store.")
       end
     end
 
@@ -272,7 +272,7 @@ describe Win32::Certstore, :windows_only do
     context "When passing empty certificate store name" do
       let(:store_name) { "" }
       it "raises ArgumentError" do
-        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Invalid Certificate Store.")
+        expect { certstore.open(store_name) }.to raise_error(ArgumentError, "Empty Certificate Store.")
       end
     end
 

--- a/spec/win32/unit/store/assertions_spec.rb
+++ b/spec/win32/unit/store/assertions_spec.rb
@@ -31,21 +31,21 @@ describe Win32::Certstore::Mixin::Assertions do
     context "When passing empty certificate store name" do
       let(:store_name) { "" }
       it "raises ArgumentError" do
-        expect { certstore.validate_store(store_name) }.to raise_error("Invalid Certificate Store.")
+        expect { certstore.validate_store(store_name) }.to raise_error("Empty Certificate Store.")
       end
     end
 
-    context "When passing invalid certificate store name" do
+    context "When passing new certificate store name" do
       let(:store_name) { "Chef" }
-      it "raises ArgumentError" do
-        expect { certstore.validate_store(store_name) }.to raise_error("Invalid Certificate Store.")
+      it "not raises ArgumentError" do
+        expect { certstore.validate_store(store_name) }.not_to raise_error("Empty Certificate Store.")
       end
     end
 
     context "When passing empty certificate store name" do
       let(:store_name) { nil }
       it "raises ArgumentError" do
-        expect { certstore.validate_store(store_name) }.to raise_error("Invalid Certificate Store.")
+        expect { certstore.validate_store(store_name) }.to raise_error("Empty Certificate Store.")
       end
     end
 


### PR DESCRIPTION
### Description
Removed store validation, Now if user open any store that not exist and want to add new certificate in that then our code will create new store for user and add new certificate in that.

### Issues Resolved

Issue: https://github.com/chef-cookbooks/windows/issues/565

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>