### PR TITLE
Delete certificate raise an exception if user pass invalid thumbprint

### DIFF
--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -87,7 +87,7 @@ module Win32
         validate_thumbprint(certificate_thumbprint)
         thumbprint = update_thumbprint(certificate_thumbprint)
         cert_pem = format_pem(get_cert_pem(thumbprint))
-        cert_rdn = get_rdn(build_openssl_obj(cert_pem))
+        cert_rdn = get_rdn(build_openssl_obj(cert_pem)) unless cert_pem.empty?
         cert_delete_flag = false
         begin
           cert_args = cert_find_args(store_handler, cert_rdn)
@@ -96,7 +96,11 @@ module Win32
           end
           CertFreeCertificateContext(pcert_context)
         rescue
-          lookup_error("delete")
+          if cert_pem.empty?
+            raise SystemCallError.new("Invalid thumbprint #{certificate_thumbprint}.")
+          else
+            lookup_error("delete")
+          end
         end
         cert_delete_flag
       end

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -266,6 +266,19 @@ describe Win32::Certstore, :windows_only do
         expect(store.delete(thumbprint)).to eql(true)
       end
     end
+
+    context "When thumbprint not found" do
+      let(:store_name) { "root" }
+      let(:thumbprint) { "invalid_thumbprint" }
+      before(:each) do
+        allow_any_instance_of(certbase).to receive(:get_cert_pem).and_return("")
+      end
+      it "returns nil" do
+        store = certstore.open(store_name)
+        cert_obj = store.get(thumbprint)
+        expect(cert_obj).to eql(nil)
+      end
+    end
   end
 
   describe "#cert_validate" do


### PR DESCRIPTION
Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>

### Description

If user pass invalid thumb-print it's throw an error `OpenSSL::X509::CertificateError - Header Too Long`

### Issues Resolved

Fixes : https://github.com/chef-cookbooks/windows/issues/569

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
