### PR TITLE
Fixes certificate get method to fetch certificate from given store.

### DIFF
--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -29,9 +29,10 @@ module Win32
     include Win32::Certstore::Mixin::String
     include Win32::Certstore::StoreBase
 
-    attr_reader :store_name
+    attr_accessor :store_name
 
     def initialize(store_name)
+      @store_name = store_name
       @certstore_handler = open(store_name)
     end
 

--- a/lib/win32/certstore/mixin/helper.rb
+++ b/lib/win32/certstore/mixin/helper.rb
@@ -23,10 +23,10 @@ module Win32
       module Helper
 
         # PSCommand to search certificate from thumbprint and convert in pem
-        def cert_ps_cmd(thumbprint)
+        def cert_ps_cmd(thumbprint, store_name)
           <<-EOH
             $content = $null
-            $cert = Get-ChildItem Cert:\ -Recurse | Where { $_.Thumbprint -eq '#{thumbprint}' }
+            $cert = Get-ChildItem Cert:\\LocalMachine\\'#{store_name}' -Recurse | Where { $_.Thumbprint -eq '#{thumbprint}' }
             if($cert -ne $null)
             {
             $content = @(

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -50,7 +50,6 @@ module Win32
       end
 
       # Get certificate from open certificate store and return certificate object
-      # store_handler => Open certificate store handler
       # certificate_thumbprint => thumbprint is a hash. which could be sha1 or md5.
       def cert_get(certificate_thumbprint)
         validate_thumbprint(certificate_thumbprint)
@@ -188,7 +187,7 @@ module Win32
 
       # Get certificate pem
       def get_cert_pem(thumbprint)
-        get_data = powershell_out!(cert_ps_cmd(thumbprint))
+        get_data = powershell_out!(cert_ps_cmd(thumbprint, store_name))
         get_data.stdout
       end
 

--- a/spec/win32/functional/win32/certstore_spec.rb
+++ b/spec/win32/functional/win32/certstore_spec.rb
@@ -1,0 +1,67 @@
+#
+# Author:: Vasundhara Jagdale (<vasundhara.jagdale@msystechnologies.com>)
+# Copyright:: 2017-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "openssl"
+
+RSpec.describe Win32::Certstore, :windows_only do
+  before { open_cert_store("My") }
+  after(:each) do
+    delete_cert
+    close_store
+  end
+
+  describe "#get" do
+    before { add_cert }
+    let(:cert_pem) { File.read('.\spec\win32\unit\assets\GlobalSignRootCA.pem') }
+
+    # passing valid thumbprint
+    it "returns the certificate_object if found" do
+      thumbprint = "b1bc968bd4f49d622aa89a81f2150152a41d829c"
+      expect(@store).to receive(:cert_get).with(thumbprint).and_return(cert_pem)
+      @store.get(thumbprint)
+    end
+
+    # passing invalid thumbprint
+    it "returns nil if certificate not found" do
+      thumbprint = "b1bc968bd4f49d622aa89a81f2150152a41d829cab"
+      expect(@store).to receive(:cert_get).with(thumbprint).and_return(nil)
+      @store.get(thumbprint)
+    end
+  end
+
+  private
+
+  def open_cert_store(store)
+    @store = Win32::Certstore.open(store)
+  end
+
+  def add_cert
+    raw = File.read ".\\spec\\win32\\unit\\assets\\GlobalSignRootCA.pem"
+    certificate_object = OpenSSL::X509::Certificate.new raw
+    @store.add(certificate_object)
+  end
+
+  def close_store
+    @store.close
+  end
+
+  def delete_cert
+    @store.delete("b1bc968bd4f49d622aa89a81f2150152a41d829c")
+  end
+end


### PR DESCRIPTION
Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
Currently get method for certificate store not getting the certificate from particular store. It finds it from all stores. Since we are performing operations by opening specific store we should modify the get method have same behaviour. Otherwise when we want to find if there is any certificate available in given store it will always return true because the same certificate is available in another store. 

### Issues Resolved
 This fix needs to be added first to fix the https://github.com/chef-cookbooks/windows/issues/578 completely.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
