### PR TITLE
Fixing deletion of a certificate by its thumbprint.

### DIFF
--- a/lib/win32/certstore/mixin/unicode.rb
+++ b/lib/win32/certstore/mixin/unicode.rb
@@ -40,11 +40,3 @@ module FFI
     end
   end
 end
-
-class String
-  include Win32::Certstore::Mixin::String
-
-  def to_wstring
-    utf8_to_wide(self)
-  end
-end

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -227,41 +227,25 @@ describe Win32::Certstore, :windows_only do
 
     context "When passing valid thumbprint" do
       let(:store_name) { "root" }
-      let(:thumbprint) { "b1bc968bd4f49d622aa89a81f2150152a41d829909c" }
       let(:cert_pem) { File.read('.\spec\win32\unit\assets\GlobalSignRootCA.pem') }
       before(:each) do
-        allow_any_instance_of(certbase).to receive(:get_cert_pem).and_return(cert_pem)
+        allow_any_instance_of(certbase).to receive(:CertFindCertificateInStore).and_return(FFI::MemoryPointer.new(1))
+        allow_any_instance_of(certbase).to receive(:CertDuplicateCertificateContext).and_return(true)
         allow_any_instance_of(certbase).to receive(:CertDeleteCertificateFromStore).and_return(true)
+        allow_any_instance_of(certbase).to receive(:CertFreeCertificateContext).and_return(true)
       end
-      it "returns true" do
+      it "returns true when thumbprint has no spaces" do
+        thumbprint = "b1bc968bd4f49d622aa89a81f2150152a41d829909c"
         store = certstore.open(store_name)
         expect(store.delete(thumbprint)).to eql(true)
       end
-    end
-
-    context "When passing valid thumbprint with spaces" do
-      let(:store_name) { "root" }
-      let(:thumbprint) { "b1 bc 96 8b d4 f4 9d 62 2a a8 9a 81 f2 15 01 52 a4 1d 82 9c" }
-      let(:cert_pem) { File.read('.\spec\win32\unit\assets\GlobalSignRootCA.pem') }
-      before(:each) do
-        allow_any_instance_of(certbase).to receive(:get_cert_pem).and_return(cert_pem)
-        allow_any_instance_of(certbase).to receive(:CertDeleteCertificateFromStore).and_return(true)
-      end
-      it "returns true" do
+      it "returns true when thumbprint has spaces" do
+        thumbprint = "b1 bc 96 8b d4 f4 9d 62 2a a8 9a 81 f2 15 01 52 a4 1d 82 9c"
         store = certstore.open(store_name)
         expect(store.delete(thumbprint)).to eql(true)
       end
-    end
-
-    context "When passing valid thumbprint with :" do
-      let(:store_name) { "root" }
-      let(:thumbprint) { "b1:bc:96:8b:d4:f4:9d:62:2a:a8:9a:81:f2:15:01:52:a4:1d:82:9c" }
-      let(:cert_pem) { File.read('.\spec\win32\unit\assets\GlobalSignRootCA.pem') }
-      before(:each) do
-        allow_any_instance_of(certbase).to receive(:get_cert_pem).and_return(cert_pem)
-        allow_any_instance_of(certbase).to receive(:CertDeleteCertificateFromStore).and_return(true)
-      end
-      it "returns true" do
+      it "returns true when thumbprint is colon(:) seperated" do
+        thumbprint = "b1:bc:96:8b:d4:f4:9d:62:2a:a8:9a:81:f2:15:01:52:a4:1d:82:9c"
         store = certstore.open(store_name)
         expect(store.delete(thumbprint)).to eql(true)
       end


### PR DESCRIPTION
- Fix deletion of a certificate by its thumbprint.
- Fetch correct certificate from the given store by its thumbprint.

- Fixes: [576](https://github.com/chef-cookbooks/windows/issues/576)

Signed-off-by: Nimesh-Msys <nimesh.patni@msystechnologies.com>

### Description

Used `CRYPT_HASH_BLOB` structure which takes `thumbprint` as an input and using this struct with `CertFindCertificateInStore`. In this way we have tried to avoid the dependency of powershell command while deleting a certificate.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
