### PR TITLE
Remove unnecessary config in the gemspec

### DIFF
--- a/win32-certstore.gemspec
+++ b/win32-certstore.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/win32-certstore"
 
   spec.files         = Dir["LICENSE", "lib/**/*"]
-  spec.bindir        = "bin"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
There's no executables in this gem so there's no reason to define this here.

Signed-off-by: Tim Smith <tsmith@chef.io>