### PR TITLE
Require ruby 2.3 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 sudo: false
+distro: xenial
 
 # Early warning system to catch if Rubygems breaks something
 before_install:
@@ -10,10 +11,10 @@ before_install:
   - gem --version
 
 rvm:
-  - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - ruby-head
 
 matrix:
@@ -23,5 +24,5 @@ matrix:
 branches:
   only:
   - master
-  
+
 script: bundle exec rake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ environment:
     - ruby_version: "25"
     - ruby_version: "24-x64"
     - ruby_version: "24"
+    - ruby_version: "23-x64"
+    - ruby_version: "23"
 
 clone_folder: c:\projects\win32-certstore
 clone_depth: 1

--- a/win32-certstore.gemspec
+++ b/win32-certstore.gemspec
@@ -6,11 +6,13 @@ require "win32/certstore/version"
 Gem::Specification.new do |spec|
   spec.name          = "win32-certstore"
   spec.version       = Win32::Certstore::VERSION
-  spec.authors       = ["nimisha"]
-  spec.email         = ["nimisha.sharad@msystechnologies.com"]
+  spec.authors       = ["Chef Software"]
+  spec.email         = ["oss@chef.io"]
   spec.license       = "Apache-2.0"
   spec.summary       = "Ruby library for accessing the certificate store on Windows."
   spec.homepage      = "https://github.com/chef/win32-certstore"
+
+  spec.required_ruby_version = ">= 2.3"
 
   spec.files         = Dir["LICENSE", "lib/**/*"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Update the gemspec to require Ruby 2.2 or later
Update the author of the gem to be Chef Software
Add Ruby 2.6 testing Travis
Add Ruby 2.3 testing in Appveyor

Signed-off-by: Tim Smith <tsmith@chef.io>