### PR TITLE
Update appveyor config and use that badge the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # win32-certstore
-[![Build Status](https://travis-ci.org/chef/win32-certstore.svg?branch=master)](https://travis-ci.org/chef/win32-certstore)
+[![Build status](https://ci.appveyor.com/api/projects/status/tgjqi0hokjjqre5x/branch/master?svg=true)](https://ci.appveyor.com/project/chef/win32-certstore/branch/master)
 [![Gem Version](https://badge.fury.io/rb/win32-certstore.svg)](https://badge.fury.io/rb/win32-certstore)
 
 Ruby library for accessing the certificate store on Microsoft Windows:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,11 @@
 version: "master-{build}"
 
-os: Visual Studio 2015
+os: Visual Studio 2017
 platform:
   - x64
 
+cache:
+  - vendor/bundle
 environment:
   matrix:
     - ruby_version: "25-x64"
@@ -15,6 +17,17 @@ environment:
 
 clone_folder: c:\projects\win32-certstore
 clone_depth: 1
+
+skip_commits:
+  # version bumps by Expeditor happen as a separate commit after the merge, we can skip
+  message: /Bump version to [0-9.]+ by Chef Expeditor/
+  # if ONLY the files listed below are changed in a commit, skip
+  files:
+    - MAINTAINERS.md
+    - MAINTAINERS.toml
+    - CHANGELOG.md
+    - RELEASE_NOTES.md
+
 skip_tags: true
 branches:
   only:


### PR DESCRIPTION
The travis tests are just to make sure we don't introduce something that
breaks chef-client on Linux, but we really care about the test results
on a windows host. Let's use the appveyor badge in the readme instead.

Signed-off-by: Tim Smith <tsmith@chef.io>