### PR TITLE
Add the ability to set specify properties in add_pfx method

### DIFF
--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -60,11 +60,12 @@ module Win32
     #
     # @param path [String] Path of the certificate that should be imported
     # @param password [String] Password of the certificate if it is protected
+    # @param key_properties [Integer] dwFlags used to specify properties of the pfx key, see certstore/store_base.rb cert_add_pfx function
     #
     # @return [Boolean]
     #
-    def add_pfx(path, password)
-      cert_add_pfx(certstore_handler, path, password)
+    def add_pfx(path, password, key_properties = 0)
+      cert_add_pfx(certstore_handler, path, password, key_properties)
     end
 
     # Return `OpenSSL::X509` certificate object

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -57,15 +57,16 @@ module Win32
       # @param certstore_handler [FFI::Pointer] Handle of the store where certificate should be imported
       # @param path [String] Path of the certificate that should be imported
       # @param password [String] Password of the certificate
+      # @param key_properties [Integer] dwFlags used to specify properties of the pfx key, see link above
       #
       # @return [Boolean]
       #
       # @raise [SystemCallError] when Crypt API would not be able to perform some action
       #
-      def cert_add_pfx(certstore_handler, path, password = "")
+      def cert_add_pfx(certstore_handler, path, password = "", key_properties = 0)
         cert_added = false
         # Imports a PFX BLOB and returns the handle of a store
-        pfx_cert_store = PFXImportCertStore(CRYPT_DATA_BLOB.new(File.binread(path)), wstring(password), 0)
+        pfx_cert_store = PFXImportCertStore(CRYPT_DATA_BLOB.new(File.binread(path)), wstring(password), key_properties)
         raise if pfx_cert_store.null?
 
         # Find all the certificate contexts in certificate store and add them ino the store


### PR DESCRIPTION
### Description

Allows a call to store.add_pfx to pass the dwFlags when importing the certificate into memory. 

### Issues Resolved

In my use case, I needed to specify a value of CRYPT_MACHINE_KEYSET (32) in order to store the key under the local computer and not under current user. 
