### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 require "bundler"
 require "bundler/gem_tasks"
 

--- a/lib/win32/certstore/mixin/assertions.rb
+++ b/lib/win32/certstore/mixin/assertions.rb
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 
 module Win32
   class Certstore

--- a/lib/win32/certstore/mixin/crypto.rb
+++ b/lib/win32/certstore/mixin/crypto.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 module Win32
   class Certstore

--- a/lib/win32/certstore/mixin/shell_out.rb
+++ b/lib/win32/certstore/mixin/shell_out.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
 module Win32
   class Certstore

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -19,8 +19,8 @@ require_relative "mixin/crypto"
 require_relative "mixin/string"
 require_relative "mixin/shell_out"
 require_relative "mixin/unicode"
-require "openssl"
-require "json"
+require "openssl" unless defined?(OpenSSL)
+require "json" unless defined?(JSON)
 
 module Win32
   class Certstore

--- a/spec/win32/functional/win32/certstore_spec.rb
+++ b/spec/win32/functional/win32/certstore_spec.rb
@@ -17,7 +17,7 @@
 #
 
 require "spec_helper"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 
 RSpec.describe Win32::Certstore, :windows_only do
   before { open_cert_store("My") }

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -17,7 +17,7 @@
 #
 
 require "spec_helper"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 
 describe Win32::Certstore, :windows_only do
 


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>