### PR TITLE
refactoring the helper.rb to put a default for output_path. Generic calls to cert_ps_cmd fail since they won't provide a path by default

### DIFF
--- a/lib/win32/certstore/mixin/helper.rb
+++ b/lib/win32/certstore/mixin/helper.rb
@@ -22,7 +22,7 @@ module Win32
     module Mixin
       module Helper
         # PSCommand to search certificate from thumbprint and either turn it into a pem or return a path to a pfx object
-        def cert_ps_cmd(thumbprint, store_location: "LocalMachine", export_password: "1234", output_path:"")
+        def cert_ps_cmd(thumbprint, store_location: "LocalMachine", export_password: "1234", output_path: "")
           <<-EOH
             $cert = Get-ChildItem Cert:\'#{store_location}' -Recurse | Where { $_.Thumbprint -eq '#{thumbprint}' }
 

--- a/lib/win32/certstore/mixin/helper.rb
+++ b/lib/win32/certstore/mixin/helper.rb
@@ -34,10 +34,8 @@ module Win32
                 if($use.FriendlyName -like "Client Authentication" ){
                     return $true
                 }
-                else {
-                    return $false
-                }
               }
+              return $false
             }
 
             $result = test_cert_values

--- a/lib/win32/certstore/mixin/helper.rb
+++ b/lib/win32/certstore/mixin/helper.rb
@@ -22,7 +22,7 @@ module Win32
     module Mixin
       module Helper
         # PSCommand to search certificate from thumbprint and either turn it into a pem or return a path to a pfx object
-        def cert_ps_cmd(thumbprint, store_location: "LocalMachine", export_password: "1234", output_path:)
+        def cert_ps_cmd(thumbprint, store_location: "LocalMachine", export_password: "1234", output_path:"")
           <<-EOH
             $cert = Get-ChildItem Cert:\'#{store_location}' -Recurse | Where { $_.Thumbprint -eq '#{thumbprint}' }
 


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>### Description


### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
