### PR TITLE
Added the -Force command to ensure proper searches

### DIFF
--- a/lib/win32/certstore/mixin/helper.rb
+++ b/lib/win32/certstore/mixin/helper.rb
@@ -24,7 +24,7 @@ module Win32
         def cert_ps_cmd(thumbprint, store_location: "LocalMachine", store_name: "My")
           # the PowerShell block below uses a "Here-String" - it is explicitly formatted against the left margin.
           <<-EOH
-            $cert = Get-ChildItem Cert:\\#{store_location}\\#{store_name} -Recurse | Where-Object { $_.Thumbprint -eq "#{thumbprint}" }
+            $cert = Get-ChildItem Cert:\\#{store_location}\\#{store_name} -Recurse -Force | Where-Object { $_.Thumbprint -eq "#{thumbprint}" }
 
             if ([string]::IsNullOrEmpty($cert)){
               return "Certificate Not Found"


### PR DESCRIPTION
Signed-off-by: John McCrae <jmccrae@chf.io>

### Description

We were searching for items in the Certificate store and Get-Childitem was doing a lazy search. The net effect was that downstream testing in the windows_certificate_spec.rb was failing because the rapid number of adds/removes to the cert store was not being caught by existing Get-ChildItem command. Adding the -Force switch forced it to actively search and thus return all the files we knew were there. 
### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
