### PR TITLE
Redirect for when the cert is not found.

### DIFF
--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -96,6 +96,7 @@ module Win32
         validate_thumbprint(certificate_thumbprint)
         thumbprint = update_thumbprint(certificate_thumbprint)
         cert_pem = get_cert_pem(thumbprint)
+        return cert_pem  if cert_pem == "Certificate Not Found"
         cert_pem = format_pem(cert_pem)
         verify_certificate(cert_pem)
         build_openssl_obj(cert_pem)


### PR DESCRIPTION
Signed-off-by: John McCrae <jmccrae@chf.io>

### Description

If the certificate is not found in the certificate store, we return a warning instead of a fault so we can log the error and continue running more gracefully. This is coupled with updates in windows_certificate to be more resilient to missing or expired certificates

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
