### PR TITLE
Updated dependencies to get ready for new Ohai for Chef-17

### DIFF
--- a/.expeditor/verify_win32certstore.ps1
+++ b/.expeditor/verify_win32certstore.ps1
@@ -23,15 +23,15 @@ refreshenv
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";c:\opscode\chef\embedded\bin"
 Write-Output "`r"
 
-Write-Output "--- :building_construction: Correcting a gem build problem, moving header files around"
-$filename = "ansidecl.h"
-$locale = Get-ChildItem -path c:\opscode -Include $filename -Recurse -ErrorAction Ignore
-if ($locale -is [Array]) { $locale = $locale[0] }
-Write-Output "Copying ansidecl.h to the correct folder"
-$parent_folder = $locale.Directory.Parent.FullName
-$child_folder = $parent_folder + "\x86_64-w64-mingw32\include"
-Copy-Item $locale.FullName -Destination $child_folder -ErrorAction Continue
-Write-Output "`r"
+# Write-Output "--- :building_construction: Correcting a gem build problem, moving header files around"
+# $filename = "ansidecl.h"
+# $locale = Get-ChildItem -path c:\opscode -Include $filename -Recurse -ErrorAction Ignore
+# if ($locale -is [Array]) { $locale = $locale[0] }
+# Write-Output "Copying ansidecl.h to the correct folder"
+# $parent_folder = $locale.Directory.Parent.FullName
+# $child_folder = $parent_folder + "\x86_64-w64-mingw32\include"
+# Copy-Item $locale.FullName -Destination $child_folder -ErrorAction Continue
+# Write-Output "`r"
 
 Write-Output "--- :bank: Installing Gems for the Chef-PowerShell Gem"
 gem install bundler

--- a/.expeditor/verify_win32certstore.ps1
+++ b/.expeditor/verify_win32certstore.ps1
@@ -26,6 +26,7 @@ Write-Output "`r"
 Write-Output "--- :building_construction: Correcting a gem build problem, moving header files around"
 $filename = "ansidecl.h"
 $locale = Get-ChildItem -path c:\opscode -Include $filename -Recurse -ErrorAction Ignore
+if ($locale -is [Array]) { $locale = $locale[0] }
 Write-Output "Copying ansidecl.h to the correct folder"
 $parent_folder = $locale.Directory.Parent.FullName
 $child_folder = $parent_folder + "\x86_64-w64-mingw32\include"
@@ -33,7 +34,7 @@ Copy-Item $locale.FullName -Destination $child_folder -ErrorAction Continue
 Write-Output "`r"
 
 Write-Output "--- :bank: Installing Gems for the Chef-PowerShell Gem"
-gem install bundler:2.2.29
+gem install bundler
 gem install libyajl2-gem
 gem install chef-powershell
 if (-not $?) { throw "unable to install this build"}

--- a/.expeditor/verify_win32certstore.ps1
+++ b/.expeditor/verify_win32certstore.ps1
@@ -23,16 +23,6 @@ refreshenv
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";c:\opscode\chef\embedded\bin"
 Write-Output "`r"
 
-# Write-Output "--- :building_construction: Correcting a gem build problem, moving header files around"
-# $filename = "ansidecl.h"
-# $locale = Get-ChildItem -path c:\opscode -Include $filename -Recurse -ErrorAction Ignore
-# if ($locale -is [Array]) { $locale = $locale[0] }
-# Write-Output "Copying ansidecl.h to the correct folder"
-# $parent_folder = $locale.Directory.Parent.FullName
-# $child_folder = $parent_folder + "\x86_64-w64-mingw32\include"
-# Copy-Item $locale.FullName -Destination $child_folder -ErrorAction Continue
-# Write-Output "`r"
-
 Write-Output "--- :bank: Installing Gems for the Chef-PowerShell Gem"
 gem install bundler
 gem install libyajl2-gem

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in win32-certstore.gemspec
 gemspec
 
-if Gem.ruby_version.to_s.start_with?("2.5")
-  # 16.7.23 required ruby 2.6+
-  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
-end
-
 group :docs do
   gem "yard"
   gem "github-markup"

--- a/win32-certstore.gemspec
+++ b/win32-certstore.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_dependency "ffi"
-  spec.add_runtime_dependency "chef-powershell", ">= 1.0.12"
+  spec.add_runtime_dependency "chef-powershell"
   spec.metadata["yard.run"] = "yri"
 end


### PR DESCRIPTION
### Description

Updated dependencies to get ready for new Ohai for Chef-17. Specifically, we need to change the chef-powershell gem dependency. 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
