### PR TITLE
CHEF-27677 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ More information on the contribution process for Chef projects can be found in t
 # LICENSE
 
 Author:: Bryan McLellan (<btm@chef.io>)
-Copyright:: 2017-2021 Chef Software, Inc.
 License:: Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -226,3 +225,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/lib/win32-certstore.rb
+++ b/lib/win32-certstore.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/win32/certstore.rb
+++ b/lib/win32/certstore.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/win32/certstore/mixin/assertions.rb
+++ b/lib/win32/certstore/mixin/assertions.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/win32/certstore/mixin/crypto.rb
+++ b/lib/win32/certstore/mixin/crypto.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/win32/certstore/mixin/helper.rb
+++ b/lib/win32/certstore/mixin/helper.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
-# Copyright:: Copyright (c) 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/win32/certstore/mixin/string.rb
+++ b/lib/win32/certstore/mixin/string.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jay Mundrawala(<jdm@chef.io>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/win32/certstore/mixin/unicode.rb
+++ b/lib/win32/certstore/mixin/unicode.rb
@@ -1,7 +1,7 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/win32/certstore/store_base.rb
+++ b/lib/win32/certstore/store_base.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/win32/functional/win32/certstore_spec.rb
+++ b/spec/win32/functional/win32/certstore_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@msystechnologies.com>)
-# Copyright:: 2017-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/win32/unit/certstore_spec.rb
+++ b/spec/win32/unit/certstore_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/win32/unit/store/assertions_spec.rb
+++ b/spec/win32/unit/store/assertions_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/win32/unit/store_base_spec.rb
+++ b/spec/win32/unit/store_base_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimesh Patni (<nimesh.patni@msystechnologies.com>)
-# Copyright:: 2017-2018 Chef Software, Inc
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/win32/unit/version_spec.rb
+++ b/spec/win32/unit/version_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2017-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `README.md:215` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
