### PR TITLE
Remove docs-team from CODEOWNERS, align with chef/chef

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*            @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners
-.expeditor/  @chef/jex-team
-*.md         @chef/docs-team
+*            @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners @jaymzh
+.expeditor/  @chef/build-engineering-systems-team


### PR DESCRIPTION
<h2>Summary</h2>
<p>Removes <code>docs-team</code> ownership from CODEOWNERS and aligns other entries with the current settings used in <a href="https://github.com/chef/chef">chef/chef</a>.</p>
<p>There really isn't a need to require <code>docs-team</code> for docs in this repo, as they don't get pushed to end users</p>
<h2>Changes</h2>
<ul>
  <li>Removed <code>*.md @chef/docs-team</code> line, matching chef/chef's recent removal of docs-team from their CODEOWNERS.</li>
  <li>Updated <code>.expeditor/</code> ownership to <code>@chef/build-engineering-systems-team</code> to match chef/chef.</li>
  <li>Added <code>@jaymzh</code> to the wildcard (<code>*</code>) rule to match chef/chef.</li>
</ul>
<h2>Tests & Coverage</h2>
<p>Documentation/config-only change (CODEOWNERS); no code, tests, or coverage impacted.</p>
<h2>Risk & Mitigations</h2>
<p>Low risk. Review routing changes only; no functional or release impact.</p>
<h2>AI Assistance</h2>
<p>This work was completed with AI assistance following Progress AI policies.</p>